### PR TITLE
do not publish container image in PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,9 @@ name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push to the main branch
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
PRs may come from forks and forks are not allowed to write to container registry, which causes the action to fail.

This should allow to merge #5 - see https://github.com/eclipse-opensmartclide/smartclide-smart-assistant/pull/5#issuecomment-1306103486